### PR TITLE
✨ Use PL callback for MLflow use case

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: trailing-whitespace
       - id: check-case-conflict
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.18.2
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]

--- a/docs/mlflow.ipynb
+++ b/docs/mlflow.ipynb
@@ -51,9 +51,10 @@
    "outputs": [],
    "source": [
     "import lamindb as ln\n",
+    "import lightning as pl\n",
     "import mlflow\n",
-    "import lightning\n",
     "\n",
+    "from pathlib import Path\n",
     "from torch import utils\n",
     "from torchvision.datasets import MNIST\n",
     "from torchvision.transforms import ToTensor\n",
@@ -247,6 +248,45 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LaminDBCheckpointCallback(pl.Callback):\n",
+    "    def __init__(self, run_id: str, artifact_uri: str):\n",
+    "        self.run_id = run_id\n",
+    "        self.artifact_uri = artifact_uri\n",
+    "        self.summary_saved = False\n",
+    "\n",
+    "    def on_train_start(\n",
+    "        self, trainer: pl.Trainer, pl_module: pl.LightningModule\n",
+    "    ) -> None:\n",
+    "        local_summary_path = (\n",
+    "            f\"{self.artifact_uri.removeprefix('file://')}/model_summary.txt\"\n",
+    "        )\n",
+    "        if Path(local_summary_path).exists() and not self.summary_saved:\n",
+    "            ln.Artifact(\n",
+    "                local_summary_path,\n",
+    "                key=f\"testmodels/mlflow/{self.run_id}_summary.txt\",\n",
+    "                kind=\"model\",\n",
+    "            ).save()\n",
+    "            self.summary_saved = True\n",
+    "\n",
+    "    def on_train_epoch_end(\n",
+    "        self, trainer: pl.Trainer, pl_module: pl.LightningModule\n",
+    "    ) -> None:\n",
+    "        ckpt_path = f\"model_checkpoints/{self.run_id}_last_epoch.ckpt\"\n",
+    "        if Path(ckpt_path).exists():\n",
+    "            ln.Artifact(\n",
+    "                ckpt_path,\n",
+    "                key=f\"testmodels/mlflow/{self.run_id}.ckpt\",\n",
+    "                kind=\"model\",\n",
+    "            ).save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
    "metadata": {
     "tags": [
      "hide-output"
@@ -254,59 +294,41 @@
    },
    "outputs": [],
    "source": [
+    "from lightning.pytorch.callbacks import ModelCheckpoint\n",
+    "\n",
     "with mlflow.start_run() as mlflow_run:\n",
     "    train_dataset = MNIST(\n",
     "        root=\"./data\", train=True, download=True, transform=ToTensor()\n",
     "    )\n",
     "    train_loader = utils.data.DataLoader(train_dataset, batch_size=32)\n",
     "\n",
-    "    # Initialize model\n",
     "    autoencoder = LitAutoEncoder(32, 16)\n",
     "\n",
-    "    # Create checkpoint callback\n",
-    "    from lightning.pytorch.callbacks import ModelCheckpoint\n",
+    "    run_id = mlflow_run.info.run_id\n",
+    "    ln.context.run.reference = run_id\n",
     "\n",
     "    checkpoint_callback = ModelCheckpoint(\n",
     "        dirpath=\"model_checkpoints\",\n",
-    "        filename=f\"{mlflow_run.info.run_id}_last_epoch\",\n",
+    "        filename=f\"{run_id}_last_epoch\",\n",
     "        save_top_k=1,\n",
     "        monitor=\"train_loss\",\n",
     "    )\n",
     "\n",
-    "    # Train model\n",
-    "    trainer = lightning.Trainer(\n",
+    "    lamindb_callback = LaminDBCheckpointCallback(run_id, mlflow_run.info.artifact_uri)\n",
+    "\n",
+    "    trainer = pl.Trainer(\n",
     "        accelerator=\"cpu\",\n",
     "        limit_train_batches=3,\n",
-    "        max_epochs=2,\n",
-    "        callbacks=[checkpoint_callback],\n",
+    "        max_epochs=3,\n",
+    "        callbacks=[checkpoint_callback, lamindb_callback],\n",
     "    )\n",
-    "    trainer.fit(model=autoencoder, train_dataloaders=train_loader)\n",
     "\n",
-    "    # Get run information\n",
-    "    run_id = mlflow_run.info.run_id\n",
-    "    ln.context.run.reference = run_id\n",
-    "\n",
-    "    # save model summary artifact\n",
-    "    local_model_summary_path = (\n",
-    "        f\"{mlflow_run.info.artifact_uri.removeprefix('file://')}/model_summary.txt\"\n",
-    "    )\n",
-    "    mlflow_model_summary_af = ln.Artifact(\n",
-    "        local_model_summary_path,\n",
-    "        key=f\"testmodels/mlflow/{local_model_summary_path}\",\n",
-    "        kind=\"model\",\n",
-    "    ).save()\n",
-    "\n",
-    "    # save checkpoint as a model\n",
-    "    mlflow_model_ckpt_af = ln.Artifact(\n",
-    "        f\"model_checkpoints/{run_id}_last_epoch.ckpt\",\n",
-    "        key=\"testmodels/mlflow/litautoencoder.ckpt\",\n",
-    "        kind=\"model\",\n",
-    "    ).save()"
+    "    trainer.fit(model=autoencoder, train_dataloaders=train_loader)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "**See the training progress in the `mlflow` UI:**\n",
@@ -316,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "**See the checkpoints:**\n",
@@ -326,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "If later on, you want to re-use the checkpoint, you can get it via:"
@@ -335,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {
     "tags": [
      "hide-output"
@@ -343,18 +365,10 @@
    },
    "outputs": [],
    "source": [
-    "mlflow_model_ckpt_af.cache()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "25",
-   "metadata": {},
-   "source": [
-    "Or on the CLI:\n",
-    "```\n",
-    "lamin get artifact --key 'testmodels/litautoencoder'\n",
-    "```"
+    "last_checkpoint_af = ln.Artifact.get(\n",
+    "    key__startswith=\"testmodels/mlflow/\", suffix__endswith=\"ckpt\", is_latest=True\n",
+    ")\n",
+    "last_checkpoint_af.cache()"
    ]
   },
   {
@@ -364,7 +378,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mlflow_model_ckpt_af.view_lineage()"
+    "last_checkpoint_af.view_lineage()"
    ]
   },
   {


### PR DESCRIPTION
We're now using a `LaminDBCheckpointCallback` which creates a new Artifact whenever an epoch ends. This makes it safe to cancel training runs midway as all checkpoints are immediately saved to LaminDB after the respective epoch has completed.